### PR TITLE
`waggle moonstream drop` is now idempotent on a per infile basis

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -397,7 +397,7 @@ func CreateMoonstreamCommand() *cobra.Command {
 	}
 
 	var blockchain, address, contractType, contractId, contractAddress, infile string
-	var limit, offset, batchSize int
+	var limit, offset, batchSize, retries int
 	var showExpired bool
 
 	contractsSubcommand := &cobra.Command{
@@ -495,7 +495,7 @@ func CreateMoonstreamCommand() *cobra.Command {
 				}
 			}
 
-			err := client.CreateCallRequests(contractId, contractAddress, limit, callRequests, batchSize)
+			err := client.CreateCallRequests(contractId, contractAddress, limit, callRequests, batchSize, retries)
 			return err
 		},
 	}
@@ -504,6 +504,7 @@ func CreateMoonstreamCommand() *cobra.Command {
 	createCallRequestsSubcommand.Flags().IntVar(&limit, "ttl-days", 30, "Number of days for which request will remain active")
 	createCallRequestsSubcommand.Flags().StringVar(&infile, "infile", "", "Input file. If not specified, input will be expected from stdin.")
 	createCallRequestsSubcommand.Flags().IntVar(&batchSize, "batch-size", 100, "Number of rows per request to API")
+	createCallRequestsSubcommand.Flags().IntVar(&retries, "retries", 1, "Number of retries for failed requests")
 
 	moonstreamCommand.AddCommand(contractsSubcommand, callRequestsSubcommand, createCallRequestsSubcommand)
 

--- a/moonstream.go
+++ b/moonstream.go
@@ -230,7 +230,7 @@ func (client *MoonstreamEngineAPIClient) sendCallRequests(requestBodyBytes []byt
 	return nil
 }
 
-func (client *MoonstreamEngineAPIClient) CreateCallRequests(contractId, contractAddress string, ttlDays int, specs []CallRequestSpecification, batchSize int) error {
+func (client *MoonstreamEngineAPIClient) CreateCallRequests(contractId, contractAddress string, ttlDays int, specs []CallRequestSpecification, batchSize, retries int) error {
 	if contractId == "" && contractAddress == "" {
 		return fmt.Errorf("you must specify at least one of contractId or contractAddress when creating call requests")
 	}
@@ -264,9 +264,8 @@ func (client *MoonstreamEngineAPIClient) CreateCallRequests(contractId, contract
 		}
 
 		sendReTryCnt := 1
-		maxSendReTryCnt := 3
 	SEND_RETRY:
-		for sendReTryCnt <= maxSendReTryCnt {
+		for sendReTryCnt <= retries {
 			sendCallRequestsErr := client.sendCallRequests(requestBodyBytes)
 			if sendCallRequestsErr == nil {
 				break SEND_RETRY
@@ -275,8 +274,8 @@ func (client *MoonstreamEngineAPIClient) CreateCallRequests(contractId, contract
 			sendReTryCnt++
 			time.Sleep(time.Duration(sendReTryCnt) * time.Second)
 
-			if sendReTryCnt > maxSendReTryCnt {
-				return fmt.Errorf("failed to send call requests")
+			if sendReTryCnt > retries {
+				fmt.Printf("failed to send call requests")
 			}
 		}
 

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-var WAGGLE_VERSION = "0.1.2"
+var WAGGLE_VERSION = "0.1.3"


### PR DESCRIPTION
The command no longer exits when retries fail.

Also added a `--retries` argument to that command.